### PR TITLE
Feature upgrade to v4

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -19,7 +19,7 @@ resource "random_integer" "rand_int" {
 
 module "resource_names" {
   source  = "terraform.registry.launch.nttdata.com/module_library/resource_name/launch"
-  version = "~> 2.0"
+  version = "~> 2.4"
 
   for_each = var.resource_names_map
 
@@ -34,7 +34,7 @@ module "resource_names" {
 
 module "resource_group" {
   source  = "terraform.registry.launch.nttdata.com/module_primitive/resource_group/azurerm"
-  version = "~> 1.0"
+  version = "~> 1.2"
 
   name     = module.resource_names["rg"].dns_compliant_minimal_random_suffix
   location = var.region

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.77"
+      version = ">= 3.77, < 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/versions.tf
+++ b/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.67.0"
+      version = ">= 3.77, < 5.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
This PR updates version constraints in the private_dns_zone module and its complete example to standardize AzureRM provider compatibility for v4 readiness.

## Changes
- Updated root module AzureRM provider constraint:
  - from `>=3.67.0`
  - to `>= 3.77, < 5.0`

- Updated complete example AzureRM provider constraint:
  - from `~> 3.77`
  - to `>= 3.77, < 5.0`

- Updated complete example module dependencies:
  - `module_library/resource_name` from `~> 2.0` to `~> 2.4`
  - `module_primitive/resource_group` from `~> 1.0` to `~> 1.2`

## Why
- Aligns provider constraints across module and example.
- Supports AzureRM v4-compatible range while explicitly avoiding v5 breaking changes.
- Keeps example dependencies aligned with currently supported module versions.

## Impact
- No functional resource logic changes.
- Scope is limited to provider/module version alignment.
- Backward risk is low for consumers already within supported ranges.

## Validation
- Compared branch diff against main.
- Verified PR scope includes only:
  - root provider version constraint
  - example provider version constraint
  - example dependency version updates

## Breaking Changes
None expected.